### PR TITLE
Permit software packaging for Linux OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /target/
+/dependency-reduced-pom.xml

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
+PREFIX ?= /usr/local
+VERSION = $(shell mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+
 all:
 	mvn package
 
 clean:
 	mvn clean
 
-.PHONY: all clean
+install: all
+	install -d -m 755 $(DESTDIR)$(PREFIX)/share/JKnobMan
+	cp -rfd build/JKnobMan-$(VERSION)/* $(DESTDIR)$(PREFIX)/share/JKnobMan/
+	install -D -m 644 misc/unix/JKnobMan.desktop $(DESTDIR)$(PREFIX)/share/applications/JKnobMan.desktop
+	install -D -m 644 res/Resource/Images/JKnobMan.png $(DESTDIR)$(PREFIX)/share/pixmaps/JKnobMan.png
+	install -D -m 755 misc/unix/jknobman.sh $(DESTDIR)$(PREFIX)/bin/jknobman
+
+.PHONY: all clean install

--- a/misc/unix/JKnobMan.desktop
+++ b/misc/unix/JKnobMan.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=JKnobMan
+Exec=jknobman
+Icon=JKnobMan
+Categories=AudioVideo;Audio;

--- a/misc/unix/jknobman.sh
+++ b/misc/unix/jknobman.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+bindir=`dirname "$0"`
+sharedir="$bindir"/../share
+exec java -jar "$sharedir"/JKnobMan/JKnobMan.jar "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,11 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-exec</artifactId>
+      <version>1.3</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -66,6 +71,31 @@
             </fileset>
           </filesets>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <configuration>
+          <minimizeJar>true</minimizeJar>
+          <filters>
+            <filter>
+              <artifact>org.apache.commons:*</artifact>
+              <excludes>
+                <exclude>META-INF/**</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,12 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-help-plugin</artifactId>
+        <version>3.2.0</version>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/GUIEditor.java
+++ b/src/main/java/GUIEditor.java
@@ -77,7 +77,7 @@ public class GUIEditor
     Control ctl;
     JMenuBar menu;
     JMenu menuRecent;
-    String strIni = new ResFilename("JKnobMan.ini").GetString();
+    String strIni = new SettingsFilename("JKnobMan.ini").GetString();
     String strIcon;
     String strNone;
     String strLangIni;

--- a/src/main/java/SettingsFilename.java
+++ b/src/main/java/SettingsFilename.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of JKnobMan.
+ * Copyright (c) 2012-2020 g200kg
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file or at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import java.io.File;
+import org.apache.commons.exec.OS;
+
+public class SettingsFilename extends ResFilename
+{
+    public SettingsFilename(String strName)
+    {
+        super(strName);
+    }
+
+    /**
+     * Returns the full path to the settings file.
+     */
+    public String GetString()
+    {
+        if (usesXdgPaths)
+        {
+            File configDir = getXdgKnobmanConfigDir();
+            File configFile = new File(configDir, this.str);
+            return configFile.toString();
+        }
+        return super.GetString();
+    }
+
+    /** Whether the configuration uses the Freedesktop path specification */
+    static boolean usesXdgPaths = !OS.isFamilyWindows() && !OS.isFamilyMac();
+
+    /**
+     * Returns the JKnobMan configuration directory for Freedesktop platforms.
+     * It is usually ~/.config/JKnobMan/.
+     */
+    private synchronized static File getXdgKnobmanConfigDir()
+    {
+        if (cacheKnobmanXdgConfigDir != null)
+        {
+            return cacheKnobmanXdgConfigDir;
+        }
+        File dir = new File(getXdgConfigDir(), "JKnobMan");
+        dir.mkdirs();
+        cacheKnobmanXdgConfigDir = dir;
+        return dir;
+    }
+
+    private static File cacheKnobmanXdgConfigDir = null;
+
+    /**
+     * Returns the configuration home directory for Freedesktop platforms.
+     * It is usually ~/.config/.
+     */
+    private static File getXdgConfigDir()
+    {
+        File dir;
+        String path = System.getenv("XDG_CONFIG_HOME");
+        if (path != null)
+        {
+            dir = new File(path);
+        }
+        else
+        {
+            path = System.getProperty("user.home");
+            dir = new File(path, ".config");
+        }
+        return dir;
+    }
+}


### PR DESCRIPTION
This change set does some modifications as follows:

- It relocates `JKnobMan.ini` in the user's personal directory.
  If the program is globally installed, the directory of the jar file is not writable, then the ini file must go elsewhere.
  In this case, the location is `~/.config/JKnobMan/`.

- It adds some installation rules based on Makefile.
  This installs a command script, and a desktop icon.