### PR TITLE
Enable default shortcuts on Linux platform

### DIFF
--- a/src/main/java/GUIEditor.java
+++ b/src/main/java/GUIEditor.java
@@ -213,6 +213,7 @@ public class GUIEditor
         }
         default: {
             this.strLaf = ppr.ReadString("laf", "");
+            this.strShortcutsIni = ppr.ReadString("shortcuts", "default.ini");
         }
         }
         this.iWheelDir = ppr.ReadInt("wheeldir", 0);


### PR DESCRIPTION
This enables PC-style shortcuts to be used on Linux OS.
On the user side, this needs to clear the old `JKnobMan.ini`  file if it exists.
The old file is saved with `shortcuts` set to empty string, which disables any shortcuts.